### PR TITLE
[cpp05/ex02] AFormクラスにexecuteメンバ関数を追加。

### DIFF
--- a/cpp05/ex02/AForm.cpp
+++ b/cpp05/ex02/AForm.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 18:28:31 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/05 08:03:59 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,9 +105,15 @@ void	AForm::beSigned(const Bureaucrat& rhs)
 
 void	AForm::execute(Bureaucrat const & executor) const
 {
+	if (this->getSign() != false) {
+		// TODO : make NotSignedException
+		// throw AForm::NotSignedException();
+		;
+	}
 	if (this->getExecuteGrade() < executor.getGrade()) {
 		throw AForm::GradeTooLowException();
 	}
+	this->action();
 }
 
 // EXCEPTION

--- a/cpp05/ex02/AForm.hpp
+++ b/cpp05/ex02/AForm.hpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 18:28:01 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/05 08:04:12 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,7 +46,7 @@ public:
 	// DESTRUCTER
 	virtual ~AForm();
 	// OPERATOR
-	AForm&	operator=(const AForm& rhs);
+	AForm&				operator=(const AForm& rhs);
 	// GETTER
 	const std::string&	getName() const;
 	const bool&			getSign() const;
@@ -55,8 +55,9 @@ public:
 	// SETTER
 	void				setSign(const bool& sign);
 	// SUBJECT FUNC
-	void	beSigned(const Bureaucrat& rhs);
-	void	execute(Bureaucrat const & executor) const;
+	void				beSigned(const Bureaucrat& rhs);
+	void				execute(Bureaucrat const & executor) const;
+	virtual void		action() const = 0;
 
 	// EXCEPTION
 	class GradeTooHighException : public std::exception {

--- a/cpp05/ex02/PresidentialPardonForm.cpp
+++ b/cpp05/ex02/PresidentialPardonForm.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 17:58:58 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/05 08:04:27 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,7 @@ PresidentialPardonForm&	PresidentialPardonForm::operator=(const PresidentialPard
 // SETTER
 
 // SUBJECT FUNC
-void	PresidentialPardonForm::informPardoned()
+void	PresidentialPardonForm::action() const
 {
 	std::cout \
 		<< BLUE << this->getName() << " has been pardoned by Zaphod Beeblebrox." << END \

--- a/cpp05/ex02/PresidentialPardonForm.hpp
+++ b/cpp05/ex02/PresidentialPardonForm.hpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 17:58:59 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/05 08:04:37 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@ public:
 	// SETTER
 
 	// SUBJECT FUNC
-	void	informPardoned();
+	void	action() const;
 
 };
 

--- a/cpp05/ex02/RobotomyRequestForm.cpp
+++ b/cpp05/ex02/RobotomyRequestForm.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 17:57:33 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/05 08:08:00 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,7 @@ RobotomyRequestForm&	RobotomyRequestForm::operator=(const RobotomyRequestForm& r
 // SETTER
 
 // SUBJECT FUNC
-void	RobotomyRequestForm::randomRequestRobotomy()
+void	RobotomyRequestForm::action() const
 {
 	try {
 		int	execFlag = std::rand() % 2;

--- a/cpp05/ex02/RobotomyRequestForm.hpp
+++ b/cpp05/ex02/RobotomyRequestForm.hpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 17:53:29 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/05 08:07:33 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,7 +46,7 @@ public:
 	// SETTER
 
 	// SUBJECT FUNC
-	void	randomRequestRobotomy();
+	void	action() const;
 	// EXCEPTION
 	class FailedRequestRobotomyException : public std::exception {
 	private:

--- a/cpp05/ex02/ShrubberyCreationForm.cpp
+++ b/cpp05/ex02/ShrubberyCreationForm.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 17:34:34 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/05 08:07:49 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -106,7 +106,7 @@ static const std::string	getFileName(const std::string& target)
 	return (fileName);
 }
 
-void	ShrubberyCreationForm::createAsciiTree()
+void	ShrubberyCreationForm::action() const
 {
 	try {
 		const std::string	fileName(getFileName(this->getName()));

--- a/cpp05/ex02/ShrubberyCreationForm.hpp
+++ b/cpp05/ex02/ShrubberyCreationForm.hpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 17:05:53 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/05 08:07:58 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ public:
 	// SETTER
 
 	// SUBJECT FUNC
-	void	createAsciiTree();
+	void	action() const;
 	// EXCEPTION
 	class FailedOpenFdException : public std::exception {
 	private:

--- a/cpp05/ex02/main.cpp
+++ b/cpp05/ex02/main.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/03 14:13:38 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 18:03:15 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/05 08:02:12 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,11 +25,11 @@ int	main()
 		ShrubberyCreationForm	form_3("../../form_3");
 		ShrubberyCreationForm	form_4("");
 		
-		form_0.createAsciiTree();
-		form_1.createAsciiTree();
-		form_2.createAsciiTree();
-		form_3.createAsciiTree();
-		form_4.createAsciiTree();
+		form_0.action();
+		form_1.action();
+		form_2.action();
+		form_3.action();
+		form_4.action();
 
 		std::cout << std::endl;
 	}
@@ -44,10 +44,10 @@ int	main()
 		RobotomyRequestForm	form_3("");
 
 		std::cout << std::endl;
-		form_0.randomRequestRobotomy();
-		form_1.randomRequestRobotomy();
-		form_2.randomRequestRobotomy();
-		form_3.randomRequestRobotomy();
+		form_0.action();
+		form_1.action();
+		form_2.action();
+		form_3.action();
 		std::cout << std::endl;
 	}
 
@@ -61,11 +61,15 @@ int	main()
 		PresidentialPardonForm		form_3("");
 
 		std::cout << std::endl;
-		form_0.informPardoned();
-		form_1.informPardoned();
-		form_2.informPardoned();
-		form_3.informPardoned();
+		form_0.action();
+		form_1.action();
+		form_2.action();
+		form_3.action();
 		std::cout << std::endl;
+	}
+
+	{
+		// Bureaucrat				user_0("user_0", 50);
 	}
 #ifdef LEAKS
 	system("leaks -q ex02");


### PR DESCRIPTION
execute()メンバ関数内で、純粋仮想関数action();を実行している。
そのため、AFormクラスを基底クラスとする派生クラスで定義したexecute();で実行したい関数の名前をaction();に変更。