### PR TITLE
[cpp05/ex02] 各クラスの例外処理を修正

### DIFF
--- a/cpp05/ex02/AForm.cpp
+++ b/cpp05/ex02/AForm.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/05 17:41:13 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/10 18:58:37 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,21 +23,21 @@ AForm::AForm(const std::string& name, const unsigned int& signGrade, const unsig
 	name_(name), sign_(false), signGrade_(signGrade), executeGrade_(execGrade)
 {
 	debugMessage("AForm", HAS_ARGS_CONSTRUCT);
-	try {
-		if (name.empty() == true) {
-			throw AForm::EmptyNameException();
-		}
-		if (signGrade < HIGHEST_RANGE || execGrade < HIGHEST_RANGE) {
-			throw AForm::GradeTooHighException();
-		}
-		if (LOWEST_RANGE < signGrade || LOWEST_RANGE < execGrade) {
-			throw AForm::GradeTooLowException();
-		}
+	// try {
+	if (name.empty() == true) {
+		throw AForm::EmptyNameException();
 	}
-	catch (std::exception& e) {
-		std::cerr << RED << e.what() << END << std::endl;
-		// throw;
+	if (signGrade < HIGHEST_RANGE || execGrade < HIGHEST_RANGE) {
+		throw AForm::GradeTooHighException();
 	}
+	if (LOWEST_RANGE < signGrade || LOWEST_RANGE < execGrade) {
+		throw AForm::GradeTooLowException();
+	}
+	// }
+	// catch (std::exception& e) {
+	// 	std::cerr << RED << e.what() << END << std::endl;
+	// 	throw;
+	// }
 }
 
 AForm::AForm(const AForm& src) :
@@ -111,7 +111,12 @@ void	AForm::execute(Bureaucrat const & executor) const
 	if (this->getExecuteGrade() < executor.getGrade()) {
 		throw AForm::GradeTooLowException();
 	}
-	this->action();
+	try {
+		this->action();
+	}
+	catch (std::exception& e) {
+		throw ;
+	}
 }
 
 // EXCEPTION

--- a/cpp05/ex02/Bureaucrat.cpp
+++ b/cpp05/ex02/Bureaucrat.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/05 09:54:04 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/10 18:49:06 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,24 +22,24 @@ Bureaucrat::Bureaucrat(const std::string& name, const unsigned int& grade) :
 	name_(name)
 {
 	debugMessage("Bureaucrat", HAS_ARGS_CONSTRUCT);
-	try {
-		if (name.empty() == true) {
-			throw Bureaucrat::EmptyNameException();
-		}
-		if (grade < HIGHEST_RANGE) {
-			this->grade_ = HIGHEST_RANGE;
-			throw Bureaucrat::GradeTooHighException();
-		}
-		if (LOWEST_RANGE < grade) {
-			this->grade_ = LOWEST_RANGE;
-			throw Bureaucrat::GradeTooLowException();
-		}
-		this->grade_ = grade;
+	// try {
+	if (name.empty() == true) {
+		throw Bureaucrat::EmptyNameException();
 	}
-	catch (std::exception& e) {
-		std::cerr << RED << e.what() << END << std::endl;
-		// throw;
+	if (grade < HIGHEST_RANGE) {
+		this->grade_ = HIGHEST_RANGE;
+		throw Bureaucrat::GradeTooHighException();
 	}
+	if (LOWEST_RANGE < grade) {
+		this->grade_ = LOWEST_RANGE;
+		throw Bureaucrat::GradeTooLowException();
+	}
+	this->grade_ = grade;
+	// }
+	// catch (std::exception& e) {
+	// 	std::cerr << RED << e.what() << END << std::endl;
+	// 	throw;
+	// }
 }
 
 Bureaucrat::Bureaucrat(const Bureaucrat& src) :
@@ -97,7 +97,6 @@ static void	actionMessage(const std::string& name, const std::string& target, co
 		<< END << std::endl;
 }
 
-// TODO
 static void	notActionMessage(const std::string& name, const std::string& target, const std::string& action)
 {
 	std::cerr \

--- a/cpp05/ex02/RobotomyRequestForm.cpp
+++ b/cpp05/ex02/RobotomyRequestForm.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/05 08:08:00 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/10 18:58:30 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,16 +59,17 @@ RobotomyRequestForm&	RobotomyRequestForm::operator=(const RobotomyRequestForm& r
 // SUBJECT FUNC
 void	RobotomyRequestForm::action() const
 {
-	try {
-		int	execFlag = std::rand() % 2;
+	// try {
+	int	execFlag = std::rand() % 2;
 
-		if (execFlag == 0) {
-			throw RobotomyRequestForm::FailedRequestRobotomyException();
-		}
-		std::cout << BLUE << this->getName() << " has been robotomized." << END << std::endl;
-	} catch (std::exception& e) {
-			std::cerr << RED << e.what() << END << std::endl;
+	if (execFlag == 0) {
+		throw RobotomyRequestForm::FailedRequestRobotomyException();
 	}
+	std::cout << BLUE << this->getName() << " has been robotomized." << END << std::endl;
+	// }
+	// catch (std::exception& e) {
+	// 	 	std::cerr << RED << e.what() << END << std::endl;
+	// }
 }
 
 // EXCEPTION

--- a/cpp05/ex02/ShrubberyCreationForm.cpp
+++ b/cpp05/ex02/ShrubberyCreationForm.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/05 08:07:49 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/10 18:57:39 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,19 +108,19 @@ static const std::string	getFileName(const std::string& target)
 
 void	ShrubberyCreationForm::action() const
 {
-	try {
-		const std::string	fileName(getFileName(this->getName()));
-		std::ofstream		fileFd(fileName.c_str()); // (std::string str); c++98
+	// try {
+	const std::string	fileName(getFileName(this->getName()));
+	std::ofstream		fileFd(fileName.c_str()); // (std::string str); c++98
 
-		if (fileFd.is_open() == false) {
-			throw ShrubberyCreationForm::FailedOpenFdException();
-		}
-		writeAsciiTree(fileFd);
-		fileFd.close();
+	if (fileFd.is_open() == false) {
+		throw ShrubberyCreationForm::FailedOpenFdException();
 	}
-	catch (std::exception& e) {
-			std::cerr << RED << e.what() << END << std::endl;
-	}
+	writeAsciiTree(fileFd);
+	fileFd.close();
+	// }
+	// catch (std::exception& e) {
+	// 		std::cerr << RED << e.what() << END << std::endl;
+	// }
 }
 
 // EXCEPTION

--- a/cpp05/ex02/main.cpp
+++ b/cpp05/ex02/main.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/03 14:13:38 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/05 10:04:32 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/10 19:03:52 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,16 +24,23 @@ int	main()
 		ShrubberyCreationForm	form_1("form_1");
 		ShrubberyCreationForm	form_2(form_1);
 		ShrubberyCreationForm	form_3("../../form_3");
-		ShrubberyCreationForm	form_4("");
-
 		std::cout << std::endl;
-		president.signForm(form_0); president.signForm(form_1); president.signForm(form_2);
-		president.signForm(form_3); president.signForm(form_4);
-
+		try {
+			ShrubberyCreationForm	form_4("");
+		}
+		catch (std::exception& e) {
+			std::cerr << RED << e.what() << END << std::endl;
+		}
 		std::cout << std::endl;
-		president.executeForm(form_0); president.executeForm(form_1); president.executeForm(form_2);
-		president.executeForm(form_3); president.executeForm(form_4);
 
+		president.signForm(form_0); president.signForm(form_1);
+		president.signForm(form_2); president.signForm(form_3);
+		// president.signForm(form_4);
+		std::cout << std::endl;
+
+		president.executeForm(form_0); president.executeForm(form_1);
+		president.executeForm(form_2); president.executeForm(form_3);
+		// president.executeForm(form_4);
 		std::cout << std::endl;
 	}
 
@@ -45,16 +52,22 @@ int	main()
 		RobotomyRequestForm	form_0;
 		RobotomyRequestForm	form_1("form_1");
 		RobotomyRequestForm	form_2(form_1);
-		RobotomyRequestForm	form_3("");
-
+		try {
+			RobotomyRequestForm	form_3("");
+		}
+		catch (std::exception& e) {
+			std::cerr << RED << e.what() << END << std::endl;
+		}
 		std::cout << std::endl;
+
 		president.signForm(form_0); president.signForm(form_1);
-		president.signForm(form_2); president.signForm(form_3);
-
+		president.signForm(form_2);
+		// president.signForm(form_3);
 		std::cout << std::endl;
-		president.executeForm(form_0); president.executeForm(form_1);
-		president.executeForm(form_2); president.executeForm(form_3);
 
+		president.executeForm(form_0); president.executeForm(form_1);
+		president.executeForm(form_2);
+		// president.executeForm(form_3);
 		std::cout << std::endl;
 	}
 
@@ -66,16 +79,23 @@ int	main()
 		PresidentialPardonForm	form_0;
 		PresidentialPardonForm	form_1("form_1");
 		PresidentialPardonForm	form_2(form_1);
-		PresidentialPardonForm	form_3("");
-
 		std::cout << std::endl;
+		try {
+			PresidentialPardonForm	form_3("");
+		}
+		catch (std::exception& e) {
+			std::cerr << RED << e.what() << END << std::endl;
+		}
+		std::cout << std::endl;
+
 		president.signForm(form_0); president.signForm(form_1);
-		president.signForm(form_2); president.signForm(form_3);
-
+		president.signForm(form_2);
+		// president.signForm(form_3);
 		std::cout << std::endl;
-		president.executeForm(form_0); president.executeForm(form_1);
-		president.executeForm(form_2); president.executeForm(form_3);
 
+		president.executeForm(form_0); president.executeForm(form_1);
+		president.executeForm(form_2);
+		// president.executeForm(form_3);
 		std::cout << std::endl;
 	}
 


### PR DESCRIPTION
Bureaucrat, AFormクラスは、コンストラクタでthrowする例外を、呼び出し元でtry {} catch() {}するようにする。
AFormクラスを継承するクラスで実装するaction()メンバ関数でthrowする例外は、呼び出し元のexecute()メンバ関数（AFormクラス）で、再送出し、さらに呼び出し元のexecuteForm()メンバ関数（Bureaucratクラス）内で、try {} catch() {}する処理に変更する。