### PR TITLE
[cpp05/ex01] reviewで指摘された箇所の修正

### DIFF
--- a/cpp05/ex01/Bureaucrat.cpp
+++ b/cpp05/ex01/Bureaucrat.cpp
@@ -6,40 +6,33 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/10 18:39:24 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/12 14:39:13 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Bureaucrat.hpp"
+#include "Form.hpp"
 
-Bureaucrat::Bureaucrat() :
-	name_(DEFAULT_NAME), grade_(150)
-{
-	debugMessage("Bureaucrat", DEFAULT_CONSTRUCT);
-}
+// Bureaucrat::Bureaucrat() :
+// 	name_(DEFAULT_NAME), grade_(150)
+// {
+// 	debugMessage("Bureaucrat", DEFAULT_CONSTRUCT);
+// }
 
-Bureaucrat::Bureaucrat(const std::string& name, const unsigned int& grade) :
+Bureaucrat::Bureaucrat(const std::string& name, const unsigned int grade) :
 	name_(name)
 {
 	debugMessage("Bureaucrat", HAS_ARGS_CONSTRUCT);
-	// try {
 	if (name.empty() == true) {
 		throw Bureaucrat::EmptyNameException();
 	}
-	if (grade < HIGHEST_RANGE) {
-		this->grade_ = HIGHEST_RANGE;
+	if (grade < this->highestRange_) {
 		throw Bureaucrat::GradeTooHighException();
 	}
-	if (LOWEST_RANGE < grade) {
-		this->grade_ = LOWEST_RANGE;
+	if (this->lowestRange_ < grade) {
 		throw Bureaucrat::GradeTooLowException();
 	}
 	this->grade_ = grade;
-	// }
-	// catch (std::exception& e) {
-	// 	std::cerr << RED << e.what() << END << std::endl;
-	// 	throw;
-	// }
 }
 
 Bureaucrat::Bureaucrat(const Bureaucrat& src) :
@@ -76,7 +69,7 @@ const unsigned int&	Bureaucrat::getGrade() const
 
 void	Bureaucrat::incrementGrade()
 {
-	if (this->grade_ == HIGHEST_RANGE) {
+	if (this->grade_ == this->highestRange_) {
 		throw Bureaucrat::GradeTooHighException();
 	}
 	this->grade_ -= 1;
@@ -84,7 +77,7 @@ void	Bureaucrat::incrementGrade()
 
 void	Bureaucrat::decrementGrade()
 {
-	if (this->grade_ == LOWEST_RANGE) {
+	if (this->grade_ == this->lowestRange_) {
 		throw Bureaucrat::GradeTooLowException();
 	}
 	this->grade_ += 1;
@@ -121,53 +114,12 @@ void	Bureaucrat::signForm(Form& rhs)
 	}
 }
 
-Bureaucrat::GradeTooHighException::GradeTooHighException() throw()
-	: message_(GRADE_TOO_HIGH_MESSAGE)
-{
-	debugMessage("GradeTooHighException", DEFAULT_CONSTRUCT);
-}
+Bureaucrat::GradeTooHighException::GradeTooHighException(const std::string& msg) : std::out_of_range(msg) {}
 
-Bureaucrat::GradeTooHighException::~GradeTooHighException() throw()
-{
-	debugMessage("GradeTooHighException", DESTRUCT);
-}
+Bureaucrat::GradeTooLowException::GradeTooLowException(const std::string& msg) : std::out_of_range(msg) {}
 
-const char*	Bureaucrat::GradeTooHighException::what() const throw()
-{
-	return (this->message_.c_str());
-}
+Bureaucrat::EmptyNameException::EmptyNameException(const std::string& msg) : std::invalid_argument(msg) {}
 
-Bureaucrat::GradeTooLowException::GradeTooLowException() throw()
-	: message_(GRADE_TOO_LOW_MESSAGE)
-{
-	debugMessage("GradeTooLowException", DEFAULT_CONSTRUCT);
-}
-
-Bureaucrat::GradeTooLowException::~GradeTooLowException() throw()
-{
-	debugMessage("GradeTooLowException", DESTRUCT);
-}
-
-const char*	Bureaucrat::GradeTooLowException::what() const throw()
-{
-	return (this->message_.c_str());
-}
-
-Bureaucrat::EmptyNameException::EmptyNameException() throw()
-	: message_(EMPTY_NAME_MESSAGE)
-{
-	debugMessage("EmptyNameException", DEFAULT_CONSTRUCT);
-}
-
-Bureaucrat::EmptyNameException::~EmptyNameException() throw()
-{
-	debugMessage("EmptyNameException", DESTRUCT);
-}
-
-const char*	Bureaucrat::EmptyNameException::what() const throw()
-{
-	return (this->message_.c_str());
-}
 std::ostream&	operator<<(std::ostream& lhs, const Bureaucrat& rhs)
 {
 	lhs << YELLOW << rhs.getName() << END \

--- a/cpp05/ex01/Bureaucrat.hpp
+++ b/cpp05/ex01/Bureaucrat.hpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/05 10:36:22 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/12 14:17:02 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,16 +15,8 @@
 
 #include "debugMessage.hpp"
 #include "color.hpp"
-#include "Form.hpp"
 #include <iostream>
 #include <exception>
-
-# define LOWEST_RANGE 150
-# define HIGHEST_RANGE 1
-# define DEFAULT_NAME "John Doe"
-# define GRADE_TOO_HIGH_MESSAGE "Grade is too high."
-# define GRADE_TOO_LOW_MESSAGE "Grade is too low."
-# define EMPTY_NAME_MESSAGE "Name is empty."
 
 class Form;
 
@@ -33,13 +25,14 @@ private:
 	// SUBJECT ATTRIBUTE
 	const std::string	name_;
 	unsigned int		grade_;
-
 	// MY ATTRIBUTE
+	const static int	lowestRange_ = 150;
+	const static int	highestRange_ = 1;
 
 public:
 	// CONSTRUCTER
-	Bureaucrat();
-	Bureaucrat(const std::string& name, const unsigned int& grade);
+	// Bureaucrat();
+	Bureaucrat(const std::string& name = "John Doe", const unsigned int grade = 150);
 	Bureaucrat(const Bureaucrat& src);
 	// DESTRUCTER
 	~Bureaucrat();
@@ -55,33 +48,17 @@ public:
 	void	decrementGrade();
 	void	signForm(Form& rhs);
 	// EXCEPTION
-	class GradeTooHighException : public std::exception {
-	private:
-		std::string	message_;
-	
+	class GradeTooHighException : public std::out_of_range {
 	public:
-		GradeTooHighException() throw();
-		~GradeTooHighException() throw();
-		const char*	what() const throw();
+		GradeTooHighException(const std::string& msg = "Grade is too high.");
 	};
-	
-	class GradeTooLowException : public std::exception {
-	private:
-		std::string	message_;
-	
+	class GradeTooLowException : public std::out_of_range {
 	public:
-		GradeTooLowException() throw();
-		~GradeTooLowException() throw();
-		const char*	what() const throw();
+		GradeTooLowException(const std::string& msg = "Grade is too low.");
 	};
-	class EmptyNameException : public std::exception {
-	private:
-		std::string	message_;
-	
+	class EmptyNameException : public std::invalid_argument {
 	public:
-		EmptyNameException() throw();
-		~EmptyNameException() throw();
-		const char*	what() const throw();
+		EmptyNameException(const std::string& msg = "Name is empty.");
 	};
 };
 

--- a/cpp05/ex01/Form.cpp
+++ b/cpp05/ex01/Form.cpp
@@ -6,38 +6,33 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/10 18:40:02 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/12 14:37:12 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Form.hpp"
+#include "Bureaucrat.hpp"
 
 // CONSTRUCTER
-Form::Form() :
-	name_(DEFAULT_FORM_NAME), sign_(false), signGrade_(150), executeGrade_(150)
-{
-	debugMessage("Form", DEFAULT_CONSTRUCT);
-}
+// Form::Form() :
+// 	name_(DEFAULT_FORM_NAME), sign_(false), signGrade_(150), executeGrade_(150)
+// {
+// 	debugMessage("Form", DEFAULT_CONSTRUCT);
+// }
 
 Form::Form(const std::string& name, const unsigned int& signGrade, const unsigned int& execGrade) :
 	name_(name), sign_(false), signGrade_(signGrade), executeGrade_(execGrade)
 {
 	debugMessage("Form", HAS_ARGS_CONSTRUCT);
-	// try {
 	if (name.empty() == true) {
 		throw Form::EmptyNameException();
 	}
-	if (signGrade < HIGHEST_RANGE || execGrade < HIGHEST_RANGE) {
+	if (signGrade < this->highestRange_ || execGrade < this->highestRange_) {
 		throw Form::GradeTooHighException();
 	}
-	if (LOWEST_RANGE < signGrade || LOWEST_RANGE < execGrade) {
+	if (this->lowestRange_ < signGrade || this->lowestRange_ < execGrade) {
 		throw Form::GradeTooLowException();
 	}
-	// }
-	// catch (std::exception& e) {
-	// 	std::cerr << RED << e.what() << END << std::endl;
-	// 	throw;
-	// }
 }
 
 Form::Form(const Form& src) :
@@ -86,10 +81,6 @@ const unsigned int&	Form::getExecuteGrade() const
 }
 
 // SETTER
-void	Form::setSign(const bool& sign)
-{
-	this->sign_ = sign;
-}
 
 // SUBJECT FUNC
 void	Form::beSigned(const Bureaucrat& rhs)
@@ -100,73 +91,17 @@ void	Form::beSigned(const Bureaucrat& rhs)
 	if (this->getSign() == true){
 		throw Form::AlreadySignedException();
 	}
-	this->setSign(true);
+	this->sign_ = true;
 }
 
 // EXCEPTION
-Form::GradeTooHighException::GradeTooHighException() throw()
-	: message_(GRADE_TOO_HIGH_MESSAGE)
-{
-	debugMessage("GradeTooHighException", DEFAULT_CONSTRUCT);
-}
+Form::GradeTooHighException::GradeTooHighException(const std::string& msg) : std::out_of_range(msg) {}
 
-Form::GradeTooHighException::~GradeTooHighException() throw()
-{
-	debugMessage("GradeTooHighException", DESTRUCT);
-}
+Form::GradeTooLowException::GradeTooLowException(const std::string& msg) : std::out_of_range(msg) {}
 
-const char*	Form::GradeTooHighException::what() const throw()
-{
-	return (this->message_.c_str());
-}
+Form::EmptyNameException::EmptyNameException(const std::string& msg) : std::invalid_argument(msg) {}
 
-Form::GradeTooLowException::GradeTooLowException() throw()
-	: message_(GRADE_TOO_LOW_MESSAGE)
-{
-	debugMessage("GradeTooLowException", DEFAULT_CONSTRUCT);
-}
-
-Form::GradeTooLowException::~GradeTooLowException() throw()
-{
-	debugMessage("GradeTooLowException", DESTRUCT);
-}
-
-const char*	Form::GradeTooLowException::what() const throw()
-{
-	return (this->message_.c_str());
-}
-
-Form::AlreadySignedException::AlreadySignedException() throw()
-	: message_(ALREADY_SIGNED_MESSAGE)
-{
-	debugMessage("AlreadySignedException", DEFAULT_CONSTRUCT);
-}
-
-Form::AlreadySignedException::~AlreadySignedException() throw()
-{
-	debugMessage("AlreadySignedException", DESTRUCT);
-}
-
-const char*	Form::AlreadySignedException::what() const throw()
-{
-	return (this->message_.c_str());
-}
-
-Form::EmptyNameException::EmptyNameException() throw()
-	: message_(EMPTY_NAME_MESSAGE)
-{
-	debugMessage("EmptyNameException", DEFAULT_CONSTRUCT);
-}
-
-Form::EmptyNameException::~EmptyNameException() throw()
-{
-	debugMessage("EmptyNameException", DESTRUCT);
-}
-
-const char*	Form::EmptyNameException::what() const throw()
-{
-	return (this->message_.c_str());
-}
+Form::AlreadySignedException::AlreadySignedException(const std::string& msg) : std::logic_error(msg) {}
 
 std::ostream&	operator<<(std::ostream& lhs, const Form& rhs)
 {

--- a/cpp05/ex01/Form.hpp
+++ b/cpp05/ex01/Form.hpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/04 12:02:02 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/12 14:38:25 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,16 +15,8 @@
 
 #include "debugMessage.hpp"
 #include "color.hpp"
-#include "Bureaucrat.hpp"
 #include <iostream>
 #include <exception>
-
-# define LOWEST_RANGE 150
-# define HIGHEST_RANGE 1
-# define DEFAULT_FORM_NAME "SAMPLE"
-# define GRADE_TOO_HIGH_MESSAGE "Grade is too high."
-# define GRADE_TOO_LOW_MESSAGE "Grade is too low."
-# define ALREADY_SIGNED_MESSAGE "Already signed."
 
 class Bureaucrat;
 
@@ -35,13 +27,14 @@ private:
 	bool				sign_;
 	const unsigned int	signGrade_;
 	const unsigned int	executeGrade_;
-
 	// MY ATTRIBUTE
+	const static int	lowestRange_ = 150;
+	const static int	highestRange_ = 1;
 
 public:
 	// CONSTRUCTER
-	Form();
-	Form(const std::string& name, const unsigned int& signGrade, const unsigned int& execGrade);
+	// Form();
+	Form(const std::string& name = "SAMPLE", const unsigned int& signGrade = 150, const unsigned int& execGrade = 150);
 	Form(const Form& src);
 	// DESTRUCTER
 	~Form();
@@ -53,45 +46,25 @@ public:
 	const unsigned int&	getSignGrade() const;
 	const unsigned int&	getExecuteGrade() const;
 	// SETTER
-	void				setSign(const bool& sign);
+
 	// SUBJECT FUNC
 	void	beSigned(const Bureaucrat& rhs);
 	// EXCEPTION
-	class GradeTooHighException : public std::exception {
-	private:
-		std::string	message_;
-	
+	class GradeTooHighException : public std::out_of_range {
 	public:
-		GradeTooHighException() throw();
-		~GradeTooHighException() throw();
-		const char*	what() const throw();
+		GradeTooHighException(const std::string& msg = "Grade is too high.");
 	};
-	class GradeTooLowException : public std::exception {
-	private:
-		std::string	message_;
-	
+	class GradeTooLowException : public std::out_of_range {
 	public:
-		GradeTooLowException() throw();
-		~GradeTooLowException() throw();
-		const char*	what() const throw();
+		GradeTooLowException(const std::string& msg = "Grade is too low.");
 	};
-	class AlreadySignedException : public std::exception {
-	private:
-		std::string	message_;
-	
+	class EmptyNameException : public std::invalid_argument {
 	public:
-		AlreadySignedException() throw();
-		~AlreadySignedException() throw();
-		const char*	what() const throw();
+		EmptyNameException(const std::string& msg = "Name is empty.");
 	};
-	class EmptyNameException : public std::exception {
-	private:
-		std::string	message_;
-	
+	class AlreadySignedException : public std::logic_error {
 	public:
-		EmptyNameException() throw();
-		~EmptyNameException() throw();
-		const char*	what() const throw();
+		AlreadySignedException(const std::string& msg = "Already signed.");
 	};
 };
 

--- a/cpp05/ex01/main.cpp
+++ b/cpp05/ex01/main.cpp
@@ -6,11 +6,12 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/03 14:13:38 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/10 18:45:59 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/12 14:37:47 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Bureaucrat.hpp"
+#include "Form.hpp"
 
 int	main()
 {


### PR DESCRIPTION
std::exceptionを継承した派生クラスの書き方を簡易的にする。
また、より具体的なexceptionを継承するようにする。