### PR TITLE
[cpp06/ex00]float型の負の数の最大値の求め方を変更する。

### DIFF
--- a/cpp06/ex00/ScalarConverter.cpp
+++ b/cpp06/ex00/ScalarConverter.cpp
@@ -6,7 +6,7 @@
 /*   By: hnoguchi <hnoguchi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 09:47:02 by hnoguchi          #+#    #+#             */
-/*   Updated: 2023/10/17 17:26:31 by hnoguchi         ###   ########.fr       */
+/*   Updated: 2023/10/19 09:47:57 by hnoguchi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,7 +134,7 @@ static void	printFloat(float f, const bool setPrecision = false, const bool impo
 
 static void	convertFloatFromDouble(const double d)
 {
-	if (d < std::numeric_limits<float>::min() || std::numeric_limits<float>::max() < d) {
+	if (d < -(std::numeric_limits<float>::max()) || std::numeric_limits<float>::max() < d) {
 		printFloat(0, true);
 	}
 	else {

--- a/playground/cpp06/limits_sample.cpp
+++ b/playground/cpp06/limits_sample.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <limits>
+
+int	main()
+{
+	std::cout << "  <char>::min(); [" << std::numeric_limits<char>::min() << "]" << std::endl;
+	std::cout << "  <char>::max(); [" << -(std::numeric_limits<char>::max()) << "]" << std::endl;
+	std::cout << std::endl;
+
+	std::cout << "   <int>::min(); [" << std::numeric_limits<int>::min() << "]" << std::endl;
+	std::cout << "   <int>::max(); [" << -(std::numeric_limits<int>::max()) << "]" << std::endl;
+	std::cout << std::endl;
+
+	std::cout << " <float>::min(); [" << std::numeric_limits<float>::min() << "]" << std::endl;
+	std::cout << " <float>::max(); [" << -(std::numeric_limits<float>::max()) << "]" << std::endl;
+	std::cout << std::endl;
+
+	std::cout << "<double>::min(); [" << std::numeric_limits<double>::min() << "]" << std::endl;
+	std::cout << "<double>::max(); [" << -(std::numeric_limits<double>::max()) << "]" << std::endl;
+	std::cout << std::endl;
+}


### PR DESCRIPTION
std::numeric_limits<float>::min();ではなくstd::numeric_limits<float>::max();にする。